### PR TITLE
Various enhancements to SLHyperalignment + 1 generic fix (for FixedNElementsTailSelector)

### DIFF
--- a/mvpa2/algorithms/searchlight_hyperalignment.py
+++ b/mvpa2/algorithms/searchlight_hyperalignment.py
@@ -8,7 +8,13 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Searchlight-based hyperalignment"""
 
+import os
 import numpy as np
+
+from tempfile import mktemp
+from numpy.linalg import LinAlgError
+from scipy.sparse import coo_matrix, csc_matrix
+
 import mvpa2
 from mvpa2.base.state import ClassWithCollections
 from mvpa2.base.param import Parameter
@@ -17,17 +23,14 @@ from mvpa2.algorithms.hyperalignment import Hyperalignment
 from mvpa2.measures.base import Measure
 from mvpa2.datasets import Dataset, vstack
 from mvpa2.mappers.staticprojection import StaticProjectionMapper
-from numpy.linalg import LinAlgError
 from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere
 from mvpa2.base.progress import ProgressBar
-import os
-from tempfile import mktemp
 from mvpa2.base.hdf5 import h5save, h5load
 from mvpa2.base import externals, warning
 from mvpa2.support import copy
-
-from scipy.sparse import coo_matrix, csc_matrix
 from mvpa2.featsel.helpers import FractionTailSelector, FixedNElementTailSelector
+
+from mvpa2.support.due import due, Doi
 
 if __debug__:
     from mvpa2.base import debug
@@ -41,7 +44,10 @@ else:
     def _shpaldebug(*args):
         return None
 
-
+@due.dcite(
+    Doi('10.1016/j.neuron.2011.08.026'),
+    description="Per-feature measure of maximal correlation to features in other datasets",
+    tags=["implementation"])
 def compute_feature_scores(datasets, exclude_from_model=None):
     """
     Takes a list of datasets and computes a magical feature
@@ -352,6 +358,11 @@ class SearchlightHyperalignment(ClassWithCollections):
         for r in results:
             yield self.__handle_results(r)
 
+
+    @due.dcite(
+        Doi('10.1093/cercor/bhw068'),
+        description="Full cortex hyperalignment of data to a common space",
+        tags=["implementation"])
     def __call__(self, datasets):
         """Estimate mappers for each dataset using searchlight-based
         hyperalignment.

--- a/mvpa2/featsel/helpers.py
+++ b/mvpa2/featsel/helpers.py
@@ -501,9 +501,12 @@ class FixedNElementTailSelector(TailSelector):
     def _set_n_elements(self, nelements):
         if __debug__:
             if nelements <= 0:
-                raise ValueError, "Number of elements less or equal to zero " \
-                                  "does not make sense."
-
+                raise ValueError("Number of elements less or equal to zero "
+                                  "does not make sense.")
+        if not isinstance(nelements, int):
+            if int(nelements) != nelements:
+                raise ValueError("nelements must be an integer. Got %s" % nelements)
+            nelements = int(nelements)
         self.__nelements = nelements
 
 

--- a/mvpa2/tests/test_searchlight_hyperalignment.py
+++ b/mvpa2/tests/test_searchlight_hyperalignment.py
@@ -157,7 +157,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
 
     @reseed_rng()
     def test_searchlight_hyperalignment(self):
-        ds_orig = datasets['3dsmall']
+        ds_orig = datasets['3dsmall'].copy()
         ds_orig.fa['voxel_indices'] = ds_orig.fa.myspace
         # toy data
         # data = np.random.randn(18,4,2)
@@ -245,6 +245,18 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         # noisy copy of original dataset should be similar to original after hyperalignment
         assert_true(np.median(ndcss[-1]) > 0.9)
         assert_true(np.all([np.median(ndcs) > 0.2 for ndcs in ndcss[1:-2]]))
+
+    @reseed_rng()
+    def test_searchlight_hyperalignment_warnings_and_exceptions(self):
+        ds_orig = datasets['3dsmall'][:, :1]  # tiny dataset just to test exceptions
+        ds_orig.fa['voxel_indices'] = ds_orig.fa.myspace
+        slhyper = SearchlightHyperalignment()
+        self.assertRaises(ValueError, slhyper, [ds_orig])  # need more than 1
+        ds_orig.samples += 1.0  # not zscored for sure
+        # TODO: we need assert_warnings to also capture our own warnings,
+        # currently they are just suppressed :-/  So this is just a smoke test
+        mappers = slhyper([ds_orig, ds_orig.copy()])
+
 
 
 def suite():  # pragma: no cover

--- a/mvpa2/tests/test_searchlight_hyperalignment.py
+++ b/mvpa2/tests/test_searchlight_hyperalignment.py
@@ -43,7 +43,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             Rs.append(ds_.a.random_rotation)
             zscore(ds_, chunks_attr=None)
             dss_rotated_clean.append(ds_)
-            ds_2 = hstack([ds_, ds4l[:, ds4l.a.bogus_features[i*4:i*4+4]]])
+            ds_2 = hstack([ds_, ds4l[:, ds4l.a.bogus_features[i * 4: i * 4 + 4]]])
             zscore(ds_2, chunks_attr=None)
             dss_rotated.append(ds_2)
         return ds_orig, dss_rotated, dss_rotated_clean, Rs
@@ -102,7 +102,8 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             nddss = []
             ndcss = []
             nf = ds_orig.nfeatures
-            ds_orig_Rref = np.dot(ds_orig.samples, Rs[ref_ds]) * np.sign(dss_rotated_clean[ref_ds].a.random_scale)
+            ds_orig_Rref = np.dot(ds_orig.samples, Rs[ref_ds]) \
+                           * np.sign(dss_rotated_clean[ref_ds].a.random_scale)
             zscore(ds_orig_Rref, chunks_attr=None)
             for ds_back in dss_clean_back:
                 ndcs = np.diag(np.corrcoef(ds_back.samples.T[:nf, ],
@@ -125,7 +126,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
                 " less for all. Got normed differences %s in %s case."
                 % (nddss, snoisy))
             self.assertTrue(
-                np.all(nddss[ref_ds] <= (.1, 0.2)[int(noisy)]),
+                nddss[ref_ds] <= (.1, 0.2)[int(noisy)],
                 msg="Should have reconstructed original dataset quite "
                 "well even with zscoring. Got normed differences %s "
                 "in %s case." % (nddss, snoisy))
@@ -165,14 +166,18 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         nds = 5
         zscore(ds_orig, chunks_attr=None)
         dss = [ds_orig]
-        # create  a few distorted datasets to match the desired number of datasets
-        # not sure if this truely mimics the real data, but at least we can test
+        # Create a few distorted datasets to match the desired number of datasets
+        # Not sure if this truely mimics the real data, but at least we can test
         # implementation
         while len(dss) <= nds - 2:
-            sd = local_random_affine_transformations(ds_orig,
-                    scatter_neighborhoods(Sphere(1),
-                    ds_orig.fa[space].value, deterministic=True)[1], Sphere(2), space=space,
-                    scale_fac=1.0, shift_fac=0.0)
+            sd = local_random_affine_transformations(
+                ds_orig,
+                scatter_neighborhoods(
+                    Sphere(1),
+                    ds_orig.fa[space].value, deterministic=True)[1],
+                Sphere(2),
+                space=space,
+                scale_fac=1.0, shift_fac=0.0)
             # sometimes above function returns dataset with nans, we don't want that.
             if np.sum(np.isnan(sd.samples)) == 0 and np.all(sd.samples.std(0)):
                 dss.append(sd)
@@ -203,7 +208,8 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         # some checks
         for midx in range(nds):
             # making sure mask_node_ids options works as expected
-            assert_array_almost_equal(projs[3][midx].proj.todense(), projs[4][midx].proj.todense())
+            assert_array_almost_equal(projs[3][midx].proj.todense(),
+                                      projs[4][midx].proj.todense())
             # recon check
             assert_array_almost_equal(projs[0][midx].proj.todense(),
                                       projs[1][midx].recon.T.todense(), decimal=5)
@@ -215,11 +221,11 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             max_weight = proj[0].proj.toarray().max(0).squeeze()
             diag_weight = proj[0].proj.diagonal()
             # Check to make sure diagonal is the max weight, in almost all rows for reference subject
-            assert(np.sum(max_weight == diag_weight)/float(len(diag_weight)) > 0.98)
+            assert(np.sum(max_weight == diag_weight) / float(len(diag_weight)) > 0.98)
             # and not true for other subjects
             for i in range(1, nds - 1):
                 assert(np.sum(proj[i].proj.toarray().max(0).squeeze() == proj[i].proj.diagonal())
-                       /float(proj[i].proj.shape[0]) < 0.80)
+                       / float(proj[i].proj.shape[0]) < 0.80)
             # Check to make sure projection weights match across duplicate datasets
             max_weight = proj[-1].proj.toarray().max(0).squeeze()
             diag_weight = proj[-1].proj.diagonal()
@@ -232,7 +238,8 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         nf = ds_orig.nfeatures
         for ds_hyper in dss_hyper:
             ndcs = np.diag(np.corrcoef(ds_hyper.samples.T,
-                                       ds_orig.samples.T)[nf:, :nf], k=0)
+                                       ds_orig.samples.T)[nf:, :nf],
+                           k=0)
             ndcss += [ndcs]
         assert_true(np.median(ndcss[0]) > 0.9)
         # noisy copy of original dataset should be similar to original after hyperalignment

--- a/mvpa2/tests/test_searchlight_hyperalignment.py
+++ b/mvpa2/tests/test_searchlight_hyperalignment.py
@@ -157,7 +157,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
 
     @reseed_rng()
     def test_searchlight_hyperalignment(self):
-        ds_orig = datasets['3dsmall'].copy()
+        ds_orig = datasets['3dsmall'].copy()[:, :15]
         ds_orig.fa['voxel_indices'] = ds_orig.fa.myspace
         # toy data
         # data = np.random.randn(18,4,2)


### PR DESCRIPTION
Now I guess we need an example... Didn't try yet (but I don't see why not) -- we could simply adjust doc/examples/hyperalignment.py to optionally do either stock original Hyperalignment or the SL one... we might even like to somehow compare results on this dataset?
