### PR TITLE
Extend use of CDist to mahalanobis distance

### DIFF
--- a/mvpa2/measures/rsa.py
+++ b/mvpa2/measures/rsa.py
@@ -33,8 +33,13 @@ class CDist(Measure):
     """
     pairwise_metric = Parameter('correlation', constraints='str', doc="""
           Distance metric to use for calculating pairwise vector distances for
-          dissimilarity matrix (DSM).  See scipy.spatial.distance.pdist for
+          dissimilarity matrix (DSM).  See scipy.spatial.distance.cdist for
           all possible metrics.""")
+
+    pairwise_metric_kwargs = Parameter({}, doc="""
+    kwargs dictionary passed to cdist. For example,
+    if `pairwise_metric='mahalanobis'`, `pairwise_metric_kwargs`
+    might contain the inverse of the covariance matrix.""")
 
     sattr = Parameter(['targets'], doc="""
         List of sample attributes whose unique values will be used to identify the
@@ -59,8 +64,9 @@ class CDist(Measure):
     def _call(self, ds):
         test_ds = self._prepare_ds(ds)
         # Call actual distance metric
-        distds = cdist(self._train_ds.samples, test_ds,
-                       metric=self.params.pairwise_metric)
+        distds = cdist(self._train_ds.samples, test_ds.samples,
+                       metric=self.params.pairwise_metric,
+                       **self.params.pairwise_metric_kwargs)
         # Make target pairs
         distds = Dataset(samples=distds.ravel()[None, ],
                          fa={'pairs': list(product(self._train_ds.T,

--- a/mvpa2/measures/rsa.py
+++ b/mvpa2/measures/rsa.py
@@ -63,7 +63,8 @@ class CDist(Measure):
                        metric=self.params.pairwise_metric)
         # Make target pairs
         distds = Dataset(samples=distds.ravel()[None, ],
-                         fa={'pairs': list(product(test_ds.UT, test_ds.UT))})
+                         fa={'pairs': list(product(self._train_ds.T,
+                                                   test_ds.T))})
         return distds
 
 

--- a/mvpa2/tests/test_rsa.py
+++ b/mvpa2/tests/test_rsa.py
@@ -91,6 +91,19 @@ def test_CDist():
         assert_array_almost_equal(res.samples.ravel(),
                                   squareform(pd_)[:3, 3:].ravel())
 
+    # check it doesn't blow up without mean group samples
+    for metric in metrics:
+        pd_ = pdist(data, metric)
+        cd_ = CDist(sattr=None, pairwise_metric=metric)
+
+        assert_true(not cd_.is_trained)
+        cd_.train(ds)
+        assert_true(cd_.is_trained)
+        res = cd_(ds)
+        # Check to make sure the pdist results are close to CDist results
+        assert_array_almost_equal(res.samples.ravel(),
+                                  squareform(pd_).ravel())
+
 
 def test_PDist():
     targets = np.tile(xrange(3),2)

--- a/mvpa2/tests/test_rsa.py
+++ b/mvpa2/tests/test_rsa.py
@@ -21,6 +21,8 @@ from mvpa2.datasets.base import dataset_wizard, Dataset
 from mvpa2.testing.tools import *
 
 from mvpa2.measures.rsa import *
+from mvpa2.generators.partition import NFoldPartitioner
+from mvpa2.measures.base import CrossValidation
 from mvpa2.base import externals
 import scipy.stats as stats
 from scipy.spatial.distance import pdist, squareform
@@ -105,6 +107,21 @@ def test_CDist():
                                   squareform(pd_).ravel())
 
 
+def test_CDist_cval():
+    targets = np.tile(range(3), 2)
+    chunks = np.repeat(np.array((0,1)), 3)
+    ds = dataset_wizard(samples=data, targets=targets, chunks=chunks)
+
+    metrics = ['euclidean', 'correlation', 'cityblock']
+    for metric in metrics:
+        cv = CrossValidation(CDist(pairwise_metric=metric),
+                             generator=NFoldPartitioner(),
+                             errorfx=None)
+        res = cv(ds)
+        assert_array_equal(res.samples[0].reshape((3, 3)),
+                           res.samples[1].reshape((3, 3)).T)
+
+
 def test_PDist():
     targets = np.tile(xrange(3),2)
     chunks = np.repeat(np.array((0,1)),3)
@@ -139,6 +156,7 @@ def test_PDist():
     # sample attributes are carried over
     assert_almost_equal(ds.sa.targets, dsm_res.sa.targets)
 
+
 def test_PDistTargetSimilarity():
     ds = Dataset(data)
     tdsm = range(15)
@@ -164,6 +182,7 @@ def test_PDistTargetSimilarity():
     assert_array_equal(a3.fa.metrics, ['rho', 'p'])
     assert_array_almost_equal(a4.samples.squeeze(), ans1[0])
     assert_array_equal(a4.fa.metrics, ['rho'])
+
 
 def test_PDistTargetSimilaritySearchlight():
     # Test ability to use PDistTargetSimilarity in a searchlight


### PR DESCRIPTION
Now it can pass kwargs to cdist, so we can use the mahalanobis distance.

Also, it tests against cdist instead of pdist, and tests the use case of cross-validation.
